### PR TITLE
20240530_okamotoVer1

### DIFF
--- a/work/CaseStudy/Assets/2D/Object/Player/saisin/Player.prefab
+++ b/work/CaseStudy/Assets/2D/Object/Player/saisin/Player.prefab
@@ -276,7 +276,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0.63}
+  m_Offset: {x: 0, y: 0.66}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -287,7 +287,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.7, y: 1}
+  m_Size: {x: 0.42, y: 1}
   m_EdgeRadius: 0
 --- !u!1 &6268105327750159728
 GameObject:
@@ -336,7 +336,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 1.62}
+  m_Offset: {x: 0, y: 1.34}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -347,7 +347,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2, y: 3}
+  m_Size: {x: 1.45, y: 2.08}
   m_EdgeRadius: 0
 --- !u!114 &8752830900292939282
 MonoBehaviour:

--- a/work/CaseStudy/Assets/2D/Scenes/O_TestScene/OTestStage02.unity
+++ b/work/CaseStudy/Assets/2D/Scenes/O_TestScene/OTestStage02.unity
@@ -1583,11 +1583,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1061781000752379446, guid: 401a965f987f3ee49be98f3179d05a4e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 30.74
+      value: 72.58
       objectReference: {fileID: 0}
     - target: {fileID: 1061781000752379446, guid: 401a965f987f3ee49be98f3179d05a4e, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.13
+      value: 12.29
       objectReference: {fileID: 0}
     - target: {fileID: 1061781000752379446, guid: 401a965f987f3ee49be98f3179d05a4e, type: 3}
       propertyPath: m_LocalPosition.z

--- a/work/CaseStudy/Assets/2D/Scenes/O_TestScene/OTestStage03.unity
+++ b/work/CaseStudy/Assets/2D/Scenes/O_TestScene/OTestStage03.unity
@@ -743,6 +743,67 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
   m_PrefabInstance: {fileID: 86039628}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &93129293
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 559645196}
+    m_Modifications:
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 28.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 23.58
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.058065
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326346, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: DownDuct
+      value: 
+      objectReference: {fileID: 1466458399}
+    - target: {fileID: 743277363613326453, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_Name
+      value: Duct
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
 --- !u!1001 &96606862
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -885,208 +946,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3c0a1f3219ee2624195f6af16bca62f7, type: 3}
---- !u!1001 &117170910
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 789203164}
-    m_Modifications:
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_RootOrder
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 54.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.25
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.05120808
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGup
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isStop
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fDistance
-      value: 1.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fWaitTime
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isRayDraw
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: mainCamera
-      value: 
-      objectReference: {fileID: 391747642}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveSpeed.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fFreezeTime
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveDistance.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGroundDistance
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Name
-      value: SEnemy (15)
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0012763143
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.000003695488
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.7587237
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.3150002
-      objectReference: {fileID: 0}
-    - target: {fileID: 736539669294422549, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000038146973
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0002925992
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.001157403
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0061026514
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.004213825
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.000007659197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0017163754
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00000008940697
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0019011497
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.37500006
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.0230951
-      objectReference: {fileID: 0}
-    - target: {fileID: 8150564939816693210, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fHitStop
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8537453767864925065, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000076293945
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00004696846
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0014364123
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.33548707
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 0.5435688
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
---- !u!4 &117170911 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 117170910}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &147955091 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 803734902209920363, guid: 3c0a1f3219ee2624195f6af16bca62f7, type: 3}
@@ -1105,208 +964,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   AnimationName: enemy_walk
---- !u!1001 &152285861
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 789203164}
-    m_Modifications:
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_RootOrder
-      value: 11
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 60.31001
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.250001
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.05120808
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGup
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isStop
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fDistance
-      value: 1.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fWaitTime
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isRayDraw
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: mainCamera
-      value: 
-      objectReference: {fileID: 391747642}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveSpeed.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fFreezeTime
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveDistance.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGroundDistance
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Name
-      value: SEnemy (16)
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0012763143
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.000003695488
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.7587237
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.3150002
-      objectReference: {fileID: 0}
-    - target: {fileID: 736539669294422549, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000038146973
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0002925992
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.001157403
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0061026514
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.004213825
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.000007659197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0017163754
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00000008940697
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0019011497
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.37500006
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.0230951
-      objectReference: {fileID: 0}
-    - target: {fileID: 8150564939816693210, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fHitStop
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8537453767864925065, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000076293945
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00004696846
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0014364123
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.33548707
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 0.5435688
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
---- !u!4 &152285862 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 152285861}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &172648121
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1647,24 +1304,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   AnimationName: enemy_walk
---- !u!1 &310634331 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1222617881103884951, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 894604182}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &310634334
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 310634331}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c99e9d7c79faffe4687f05a71dc47129, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AnimationName: enemy_walk
 --- !u!1001 &319101939
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1786,24 +1425,67 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 65133dadd0e7b634ea2df3cb1a179ab0, type: 3}
---- !u!1 &322838686 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1222617881103884951, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 1647140695}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &322838689
-MonoBehaviour:
+--- !u!1001 &349663676
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 322838686}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c99e9d7c79faffe4687f05a71dc47129, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AnimationName: enemy_walk
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 559645196}
+    m_Modifications:
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 54.49
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 18.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.058065
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 743277363613326346, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: UpDuct
+      value: 
+      objectReference: {fileID: 1552770556}
+    - target: {fileID: 743277363613326453, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+      propertyPath: m_Name
+      value: Duct (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
 --- !u!4 &386293360 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
@@ -2473,7 +2155,7 @@ Transform:
   - {fileID: 468892772}
   - {fileID: 1236763293}
   m_Father: {fileID: 559645196}
-  m_RootOrder: 7
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &488365634 stripped
 GameObject:
@@ -2810,10 +2492,11 @@ Transform:
   - {fileID: 1743279845}
   - {fileID: 646626202}
   - {fileID: 709132878}
-  - {fileID: 789203164}
   - {fileID: 1695191903}
-  - {fileID: 1773619369}
   - {fileID: 486586978}
+  - {fileID: 1773619369}
+  - {fileID: 1552770562}
+  - {fileID: 1466458400}
   m_Father: {fileID: 0}
   m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2949,208 +2632,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   AnimationName: enemy_walk
---- !u!1001 &641044132
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 789203164}
-    m_Modifications:
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_RootOrder
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 57.11
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.25
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.05120808
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGup
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isStop
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fDistance
-      value: 1.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fWaitTime
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isRayDraw
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: mainCamera
-      value: 
-      objectReference: {fileID: 391747642}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveSpeed.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fFreezeTime
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveDistance.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGroundDistance
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Name
-      value: SEnemy (14)
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0012763143
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.000003695488
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.7587237
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.3150002
-      objectReference: {fileID: 0}
-    - target: {fileID: 736539669294422549, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000038146973
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0002925992
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.001157403
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0061026514
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.004213825
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.000007659197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0017163754
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00000008940697
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0019011497
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.37500006
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.0230951
-      objectReference: {fileID: 0}
-    - target: {fileID: 8150564939816693210, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fHitStop
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8537453767864925065, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000076293945
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00004696846
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0014364123
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.33548707
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 0.5435688
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
---- !u!4 &641044133 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 641044132}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &646626201
 GameObject:
   m_ObjectHideFlags: 0
@@ -3465,248 +2946,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   AnimationName: enemy_walk
---- !u!1 &789203163
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 789203164}
-  m_Layer: 0
-  m_Name: Duct
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &789203164
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 789203163}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -3.5080605, y: 12.278709, z: -3.058065}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 894604183}
-  - {fileID: 827545016}
-  - {fileID: 1024304264}
-  - {fileID: 1647140696}
-  - {fileID: 991542495}
-  - {fileID: 1992252864}
-  - {fileID: 117170911}
-  - {fileID: 641044133}
-  - {fileID: 152285862}
-  m_Father: {fileID: 559645196}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &827545015
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 789203164}
-    m_Modifications:
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 70.06
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 7.119999
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.05120808
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGup
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isStop
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fDistance
-      value: 1.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fWaitTime
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isRayDraw
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: mainCamera
-      value: 
-      objectReference: {fileID: 391747642}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveSpeed.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fFreezeTime
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveDistance.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGroundDistance
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Name
-      value: SEnemy (10)
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0012763143
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.000003695488
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.7587237
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.3150002
-      objectReference: {fileID: 0}
-    - target: {fileID: 736539669294422549, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000038146973
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0002925992
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.001157403
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0061026514
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.004213825
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.000007659197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0017163754
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00000008940697
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0019011497
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.37500006
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.0230951
-      objectReference: {fileID: 0}
-    - target: {fileID: 8150564939816693210, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fHitStop
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8537453767864925065, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000076293945
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00004696846
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0014364123
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.33548707
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 0.5435688
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
---- !u!4 &827545016 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 827545015}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &847344922
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3798,208 +3037,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   AnimationName: enemy_walk
---- !u!1001 &894604182
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 789203164}
-    m_Modifications:
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 67.149994
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 7.119999
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.05120808
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGup
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isStop
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fDistance
-      value: 1.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fWaitTime
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isRayDraw
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: mainCamera
-      value: 
-      objectReference: {fileID: 391747642}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveSpeed.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fFreezeTime
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveDistance.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGroundDistance
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Name
-      value: SEnemy (8)
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0012763143
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.000003695488
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.7587237
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.3150002
-      objectReference: {fileID: 0}
-    - target: {fileID: 736539669294422549, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000038146973
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0002925992
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.001157403
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0061026514
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.004213825
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.000007659197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0017163754
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00000008940697
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0019011497
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.37500006
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.0230951
-      objectReference: {fileID: 0}
-    - target: {fileID: 8150564939816693210, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fHitStop
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8537453767864925065, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000076293945
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00004696846
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0014364123
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.33548707
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 0.5435688
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
---- !u!4 &894604183 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 894604182}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &906658849 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1222617881103884951, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
@@ -4572,24 +3609,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
   m_PrefabInstance: {fileID: 947357061}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &972143420 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1222617881103884951, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 641044132}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &972143423
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 972143420}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c99e9d7c79faffe4687f05a71dc47129, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AnimationName: enemy_walk
 --- !u!1 &974250272 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 803734902209920363, guid: 3c0a1f3219ee2624195f6af16bca62f7, type: 3}
@@ -4669,410 +3688,6 @@ PrefabInstance:
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5279419861592167256, guid: 7878c2b88e3e20045b063989d6f24529, type: 3}
   m_PrefabInstance: {fileID: 983229435}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &991542494
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 789203164}
-    m_Modifications:
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_RootOrder
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 75.95
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.25
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.05120808
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGup
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isStop
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fDistance
-      value: 1.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fWaitTime
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isRayDraw
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: mainCamera
-      value: 
-      objectReference: {fileID: 391747642}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveSpeed.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fFreezeTime
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveDistance.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGroundDistance
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Name
-      value: SEnemy (11)
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0012763143
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.000003695488
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.7587237
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.3150002
-      objectReference: {fileID: 0}
-    - target: {fileID: 736539669294422549, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000038146973
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0002925992
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.001157403
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0061026514
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.004213825
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.000007659197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0017163754
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00000008940697
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0019011497
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.37500006
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.0230951
-      objectReference: {fileID: 0}
-    - target: {fileID: 8150564939816693210, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fHitStop
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8537453767864925065, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000076293945
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00004696846
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0014364123
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.33548707
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 0.5435688
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
---- !u!4 &991542495 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 991542494}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1024304263
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 789203164}
-    m_Modifications:
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_RootOrder
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 73.26
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 7.12
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.05120808
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGup
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isStop
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fDistance
-      value: 1.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fWaitTime
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isRayDraw
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: mainCamera
-      value: 
-      objectReference: {fileID: 391747642}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveSpeed.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fFreezeTime
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveDistance.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGroundDistance
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Name
-      value: SEnemy (09)
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0012763143
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.000003695488
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.7587237
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.3150002
-      objectReference: {fileID: 0}
-    - target: {fileID: 736539669294422549, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000038146973
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0002925992
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.001157403
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0061026514
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.004213825
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.000007659197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0017163754
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00000008940697
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0019011497
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.37500006
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.0230951
-      objectReference: {fileID: 0}
-    - target: {fileID: 8150564939816693210, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fHitStop
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8537453767864925065, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000076293945
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00004696846
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0014364123
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.33548707
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 0.5435688
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
---- !u!4 &1024304264 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 1024304263}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1035338006
 GameObject:
@@ -13169,24 +11784,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: eaba9cd99decefb40930304fb2faf288, type: 3}
---- !u!1 &1344702843 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1222617881103884951, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 827545015}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1344702846
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1344702843}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c99e9d7c79faffe4687f05a71dc47129, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AnimationName: enemy_walk
 --- !u!1001 &1348837440
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13254,24 +11851,6 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1905725172142954792, guid: 3c0a1f3219ee2624195f6af16bca62f7, type: 3}
   m_PrefabInstance: {fileID: 43835707}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1394521632 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1222617881103884951, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 1992252863}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1394521635
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1394521632}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c99e9d7c79faffe4687f05a71dc47129, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AnimationName: enemy_walk
 --- !u!1001 &1420462371
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13510,6 +12089,16 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1466458399 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 743277363613326453, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+  m_PrefabInstance: {fileID: 349663676}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1466458400 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+  m_PrefabInstance: {fileID: 349663676}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1502441337 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1905725172142954792, guid: 3c0a1f3219ee2624195f6af16bca62f7, type: 3}
@@ -13859,6 +12448,16 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1552770556 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 743277363613326453, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+  m_PrefabInstance: {fileID: 93129293}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1552770562 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 743277363613326345, guid: f9865e6f34cd3e142a99ced1e07092cd, type: 3}
+  m_PrefabInstance: {fileID: 93129293}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1604557477
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13932,226 +12531,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3c0a1f3219ee2624195f6af16bca62f7, type: 3}
---- !u!1 &1625302193 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1222617881103884951, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 152285861}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1625302196
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1625302193}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c99e9d7c79faffe4687f05a71dc47129, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AnimationName: enemy_walk
---- !u!1001 &1647140695
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 789203164}
-    m_Modifications:
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 73.04
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.25
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.05120808
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGup
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isStop
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fDistance
-      value: 1.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fWaitTime
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isRayDraw
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: mainCamera
-      value: 
-      objectReference: {fileID: 391747642}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveSpeed.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fFreezeTime
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveDistance.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGroundDistance
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Name
-      value: SEnemy (12)
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0012763143
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.000003695488
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.7587237
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.3150002
-      objectReference: {fileID: 0}
-    - target: {fileID: 736539669294422549, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000038146973
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0002925992
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.001157403
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0061026514
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.004213825
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.000007659197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0017163754
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00000008940697
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0019011497
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.37500006
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.0230951
-      objectReference: {fileID: 0}
-    - target: {fileID: 8150564939816693210, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fHitStop
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8537453767864925065, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000076293945
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00004696846
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0014364123
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.33548707
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 0.5435688
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
---- !u!4 &1647140696 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 1647140695}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1651423278 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1222617881103884951, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
@@ -14244,7 +12623,7 @@ RectTransform:
   m_Children:
   - {fileID: 1748603391}
   m_Father: {fileID: 559645196}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -14312,24 +12691,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!1 &1702370415 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1222617881103884951, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 1024304263}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1702370418
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1702370415}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c99e9d7c79faffe4687f05a71dc47129, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AnimationName: enemy_walk
 --- !u!1001 &1710259774
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -46877,24 +45238,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3c0a1f3219ee2624195f6af16bca62f7, type: 3}
---- !u!1 &1918089387 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1222617881103884951, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 991542494}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1918089390
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1918089387}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c99e9d7c79faffe4687f05a71dc47129, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AnimationName: enemy_walk
 --- !u!1 &1920401823 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 803734902209920363, guid: 3c0a1f3219ee2624195f6af16bca62f7, type: 3}
@@ -47207,208 +45550,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ebfb7cf9a2f7e654aa4600c7080c0fcc, type: 3}
---- !u!1001 &1992252863
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 789203164}
-    m_Modifications:
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_RootOrder
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 79.15001
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.250001
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.05120808
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGup
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isStop
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fDistance
-      value: 1.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fWaitTime
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: isRayDraw
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: mainCamera
-      value: 
-      objectReference: {fileID: 391747642}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveSpeed.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fFreezeTime
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: MoveDistance.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437967, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fGroundDistance
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Name
-      value: SEnemy (13)
-      objectReference: {fileID: 0}
-    - target: {fileID: 117817261664437972, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0012763143
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.000003695488
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.7587237
-      objectReference: {fileID: 0}
-    - target: {fileID: 400926434240787900, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.3150002
-      objectReference: {fileID: 0}
-    - target: {fileID: 736539669294422549, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000038146973
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0002925992
-      objectReference: {fileID: 0}
-    - target: {fileID: 1781904181341005208, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.001157403
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.0061026514
-      objectReference: {fileID: 0}
-    - target: {fileID: 4602170221228839387, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.004213825
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.000007659197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5663730911833035984, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0017163754
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00000008940697
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: 0.0019011497
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.37500006
-      objectReference: {fileID: 0}
-    - target: {fileID: 7540922429941640397, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 1.0230951
-      objectReference: {fileID: 0}
-    - target: {fileID: 8150564939816693210, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: fHitStop
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8537453767864925065, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0000076293945
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.x
-      value: 0.00004696846
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Center.y
-      value: -0.0014364123
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.x
-      value: 0.33548707
-      objectReference: {fileID: 0}
-    - target: {fileID: 8764292635536093893, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-      propertyPath: m_Bounds.m_Extent.y
-      value: 0.5435688
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
---- !u!4 &1992252864 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 117817261664437955, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 1992252863}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2011938561
 GameObject:
   m_ObjectHideFlags: 0
@@ -47881,24 +46022,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9b95bb7ad1ad52540bff17d7343f58d9, type: 3}
---- !u!1 &2066361788 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1222617881103884951, guid: 8f6496a0a5aa5284ca1aab711d93a9ae, type: 3}
-  m_PrefabInstance: {fileID: 117170910}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &2066361791
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2066361788}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c99e9d7c79faffe4687f05a71dc47129, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  AnimationName: enemy_walk
 --- !u!1 &2075673202 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1905725172142954792, guid: 3c0a1f3219ee2624195f6af16bca62f7, type: 3}

--- a/work/CaseStudy/Assets/Image/Effect/Eff_ScatterEnemy.prefab
+++ b/work/CaseStudy/Assets/Image/Effect/Eff_ScatterEnemy.prefab
@@ -977,7 +977,7 @@ ParticleSystem:
       countCurve:
         serializedVersion: 2
         minMaxState: 0
-        scalar: 6
+        scalar: 3
         minScalar: 30
         maxCurve:
           serializedVersion: 2


### PR DESCRIPTION
プレイヤーのプレハブのコライダーを調整して、地面のタイルマップとの見た目を合わせました。
プレイヤーにisCollider の入っていないボックスコライダーが二つあるので敵との接触判定も兼ねている
リスポーン用の子オブジェクトのコライダーを気持ち大きめに設定しています。
