### PR TITLE
鳴けなくした＋風後の先走り待機

### DIFF
--- a/work/CaseStudy/Assets/2D/Script/Player/M_PlayerPush.cs
+++ b/work/CaseStudy/Assets/2D/Script/Player/M_PlayerPush.cs
@@ -129,6 +129,7 @@ public class M_PlayerPush : MonoBehaviour
         if (animator.GetCurrentAnimatorStateInfo(0).IsName("kaze01"))
         {
             PlayerObj.GetComponent<M_PlayerMove>().SetIsMove(false);
+            animator.SetBool("run", false);
         }
         else
         {

--- a/work/CaseStudy/Assets/2D/Script/Player/N_ProjecterSympathy.cs
+++ b/work/CaseStudy/Assets/2D/Script/Player/N_ProjecterSympathy.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 
 public class N_ProjecterSympathy : MonoBehaviour
 {
+    [Header("鳴けるか"), SerializeField]
+    private bool canSympathy = true;
+
     [Header("広がるスピード"), SerializeField]
     private float fSpreadSpeed = 1.0f;
 
@@ -90,6 +93,12 @@ public class N_ProjecterSympathy : MonoBehaviour
             }
 
             isInitialized = true;
+        }
+
+        // 鳴けないようにする
+        if (!canSympathy)
+        {
+            return;
         }
 
         // キー入力があったら共鳴開始


### PR DESCRIPTION
鳴くかどうかをインスペクターで設定できるようにした。泣かせたくないシーンのプレイヤーのインスペクターから設定してください。プレハブではいじらないこと。 風を出した後スティック入力すると、移動せずに走るアニメーションが再生されるバグ修正