### PR TITLE
敵の索敵とプレイヤーの風のレイ修正

### DIFF
--- a/work/CaseStudy/Assets/2D/Object/Enemy/Sawano/Enemy_Mark.1.prefab
+++ b/work/CaseStudy/Assets/2D/Object/Enemy/Sawano/Enemy_Mark.1.prefab
@@ -19,7 +19,7 @@ GameObject:
   - component: {fileID: 377446080215070972}
   - component: {fileID: 3559411171947690459}
   - component: {fileID: 5297312615223750310}
-  m_Layer: 2
+  m_Layer: 7
   m_Name: Enemy_Mark.1
   m_TagString: Enemy
   m_Icon: {fileID: 0}
@@ -246,6 +246,7 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 321
   sc_GroundCheck: {fileID: 1141245237961300279}
+  OldisWarped: 0
 --- !u!82 &7695652855729107506
 AudioSource:
   m_ObjectHideFlags: 0

--- a/work/CaseStudy/Assets/2D/Object/Player/saisin/Player.prefab
+++ b/work/CaseStudy/Assets/2D/Object/Player/saisin/Player.prefab
@@ -386,6 +386,7 @@ MonoBehaviour:
   acCheckPoint: {fileID: 8300000, guid: 3c57f0472cee5cc44a8ab08032b4d8d2, type: 3}
   RespwanTime: 3
   SmokePrefab: {fileID: 7367885248579283801, guid: 0ee9ef57aada90a46848a92f5e86d45d, type: 3}
+  SmokeOffset: {x: 0, y: 0}
   acSmokeScreen: {fileID: 8300000, guid: 4f5008068b5b96d4a9928bbce96a3e11, type: 3}
   isRespawn: 0
 --- !u!82 &2382190773623950448
@@ -562,6 +563,10 @@ PrefabInstance:
     - target: {fileID: 7310569821080857450, guid: 66dbb2f8cfed78c4ca7d8b7ad066fb04, type: 3}
       propertyPath: fDlayAnim
       value: 0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 7310569821080857450, guid: 66dbb2f8cfed78c4ca7d8b7ad066fb04, type: 3}
+      propertyPath: layerMask.m_Bits
+      value: 448
       objectReference: {fileID: 0}
     - target: {fileID: 7455578348281846349, guid: 66dbb2f8cfed78c4ca7d8b7ad066fb04, type: 3}
       propertyPath: m_Name

--- a/work/CaseStudy/Assets/2D/Scenes/N_TestScene/NTestScene_3.unity
+++ b/work/CaseStudy/Assets/2D/Scenes/N_TestScene/NTestScene_3.unity
@@ -544,7 +544,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 346455752079443109, guid: a134b1118bb701140a06a5805f0ca398, type: 3}
       propertyPath: m_RootOrder
-      value: 19
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 346455752079443109, guid: a134b1118bb701140a06a5805f0ca398, type: 3}
       propertyPath: m_AnchorMax.x
@@ -655,7 +655,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7461009736470124189, guid: 7c95b1b7069c66341bc26ebe5b2d0f2c, type: 3}
       propertyPath: m_RootOrder
-      value: 18
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 7461009736470124189, guid: 7c95b1b7069c66341bc26ebe5b2d0f2c, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1021,7 +1021,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5075576872332185925, guid: 25d041bc83372dd44bd5d88d9f7501e5, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 5075576872332185925, guid: 25d041bc83372dd44bd5d88d9f7501e5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1852,7 +1852,7 @@ Transform:
   - {fileID: 1773619369}
   - {fileID: 1539522633}
   m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &626399034
 GameObject:
@@ -1947,6 +1947,10 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6372921232022759936, guid: c793d23110b397448b2ff7991f372973, type: 3}
+      propertyPath: isProjection
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6372921232022759936, guid: c793d23110b397448b2ff7991f372973, type: 3}
       propertyPath: AwayDistance.y
       value: 0
       objectReference: {fileID: 0}
@@ -2026,7 +2030,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3971798872968596973, guid: d2c637a46c20e0b43bc33b3578c75b00, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 3971798872968596973, guid: d2c637a46c20e0b43bc33b3578c75b00, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2232,7 +2236,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1396957527884846906, guid: b40c85a2aafddac4fbb5d52c0f907d0b, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1396957527884846907, guid: b40c85a2aafddac4fbb5d52c0f907d0b, type: 3}
       propertyPath: buttons.Array.data[1]
@@ -2608,7 +2612,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6105006451457661067, guid: 58c7e0a317ed71d4bbc685335566bf58, type: 3}
       propertyPath: m_RootOrder
-      value: 17
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 6105006451457661067, guid: 58c7e0a317ed71d4bbc685335566bf58, type: 3}
       propertyPath: m_AnchorMax.x
@@ -2692,6 +2696,63 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 58c7e0a317ed71d4bbc685335566bf58, type: 3}
+--- !u!1001 &976269937
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1497359285853439715, guid: ebfb7cf9a2f7e654aa4600c7080c0fcc, type: 3}
+      propertyPath: m_Name
+      value: BreakBlock
+      objectReference: {fileID: 0}
+    - target: {fileID: 1497359285853439718, guid: ebfb7cf9a2f7e654aa4600c7080c0fcc, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1497359285853439718, guid: ebfb7cf9a2f7e654aa4600c7080c0fcc, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 67.93055
+      objectReference: {fileID: 0}
+    - target: {fileID: 1497359285853439718, guid: ebfb7cf9a2f7e654aa4600c7080c0fcc, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 20.546915
+      objectReference: {fileID: 0}
+    - target: {fileID: 1497359285853439718, guid: ebfb7cf9a2f7e654aa4600c7080c0fcc, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1497359285853439718, guid: ebfb7cf9a2f7e654aa4600c7080c0fcc, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1497359285853439718, guid: ebfb7cf9a2f7e654aa4600c7080c0fcc, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1497359285853439718, guid: ebfb7cf9a2f7e654aa4600c7080c0fcc, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1497359285853439718, guid: ebfb7cf9a2f7e654aa4600c7080c0fcc, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1497359285853439718, guid: ebfb7cf9a2f7e654aa4600c7080c0fcc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1497359285853439718, guid: ebfb7cf9a2f7e654aa4600c7080c0fcc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1497359285853439718, guid: ebfb7cf9a2f7e654aa4600c7080c0fcc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ebfb7cf9a2f7e654aa4600c7080c0fcc, type: 3}
 --- !u!1001 &979674137
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2713,7 +2774,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3685330130811067434, guid: b9962a499bf789c40be4b3f64013e116, type: 3}
       propertyPath: m_RootOrder
-      value: 16
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 3685330130811067434, guid: b9962a499bf789c40be4b3f64013e116, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3056,11 +3117,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1061781000752379446, guid: 401a965f987f3ee49be98f3179d05a4e, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1061781000752379446, guid: 401a965f987f3ee49be98f3179d05a4e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 62.96
+      value: 57.47
       objectReference: {fileID: 0}
     - target: {fileID: 1061781000752379446, guid: 401a965f987f3ee49be98f3179d05a4e, type: 3}
       propertyPath: m_LocalPosition.y
@@ -3483,6 +3544,10 @@ PrefabInstance:
       value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7083271406795752283, guid: 65133dadd0e7b634ea2df3cb1a179ab0, type: 3}
+      propertyPath: IsReflectionX
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083271406795752283, guid: 65133dadd0e7b634ea2df3cb1a179ab0, type: 3}
       propertyPath: TeamMembers.Array.size
       value: 3
       objectReference: {fileID: 0}
@@ -3631,7 +3696,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9032567230447829897, guid: eaba9cd99decefb40930304fb2faf288, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 9032567230447829897, guid: eaba9cd99decefb40930304fb2faf288, type: 3}
       propertyPath: m_AnchorMax.x
@@ -3922,7 +3987,7 @@ Transform:
   - {fileID: 626399035}
   - {fileID: 676080867}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1515360685
 PrefabInstance:
@@ -4271,7 +4336,7 @@ Transform:
   - {fileID: 1130051247}
   - {fileID: 508073657}
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1568159496
 PrefabInstance:
@@ -37561,7 +37626,7 @@ RectTransform:
   m_Children:
   - {fileID: 255884834}
   m_Father: {fileID: 0}
-  m_RootOrder: 13
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -37774,7 +37839,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 6585438994767444665, guid: 9b95bb7ad1ad52540bff17d7343f58d9, type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 6585438994767444665, guid: 9b95bb7ad1ad52540bff17d7343f58d9, type: 3}
       propertyPath: m_LocalPosition.x
@@ -38097,7 +38162,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7487603991789896488, guid: ab3a700d949cf5c4c8b54611be3570ed, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 7487603991789896488, guid: ab3a700d949cf5c4c8b54611be3570ed, type: 3}
       propertyPath: m_LocalPosition.x
@@ -38428,7 +38493,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2828518646370106489, guid: 9475ca8365bd28b47aec08c10a477ebe, type: 3}
       propertyPath: m_RootOrder
-      value: 20
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 6735367542577297959, guid: 9475ca8365bd28b47aec08c10a477ebe, type: 3}
       propertyPath: m_Name

--- a/work/CaseStudy/Assets/2D/Script/Enemy/N_GroundCheck.cs
+++ b/work/CaseStudy/Assets/2D/Script/Enemy/N_GroundCheck.cs
@@ -44,7 +44,7 @@ public class N_GroundCheck : MonoBehaviour
 
         foreach(var a in colList)
         {
-            Debug.Log(a.name);
+            //Debug.Log(a.name);
 
         }
     }

--- a/work/CaseStudy/Assets/2D/Script/Enemy/N_PlayerSearch.cs
+++ b/work/CaseStudy/Assets/2D/Script/Enemy/N_PlayerSearch.cs
@@ -61,7 +61,7 @@ public class N_PlayerSearch : MonoBehaviour
 
             // ’ÇÕ‘ÎÛ‚ª‹–ì”ÍˆÍ“à‚É“ü‚Á‚½
             // •Ç‚ğ‹²‚ñ‚Å‚¢‚é‚©‚ğ”»’è‚·‚é
-            if (isRaycast && !isCheck)
+            if (isRaycast /*&& !isCheck*/)
             {
                 RayCastCheck();
             }
@@ -129,12 +129,12 @@ public class N_PlayerSearch : MonoBehaviour
         {
             direction = Vector2.left;
         }
-        float distance = elapsedTime * 6.0f;
+        float distance = elapsedTime * 30.0f;
         elapsedTime += Time.deltaTime;
 
         RaycastHit2D hit = Physics2D.Raycast(startPoint, direction,distance,layerMask);
 
-        //Debug.DrawRay(startPoint, direction * distance, Color.black, 0.0f, false);
+        Debug.DrawRay(startPoint, direction * distance, Color.black, 0.0f, false);
 
         // æ‚É“G‚É“–‚½‚Á‚½‚ç’ÇÕ
         // •Ç‚É“–‚½‚Á‚½‚ç‚È‚É‚à‚È‚µ
@@ -149,14 +149,14 @@ public class N_PlayerSearch : MonoBehaviour
                 //Debug.Log("Ú“G");
                 isSearch = true;
                 enemyManager.SetTarget(Target);
-                isRaycast = false;
+                //isRaycast = false;
             }
             else if(hit.collider.gameObject.name == "Tilemap_Col")
             {
                 //Debug.Log("•ÇŒŸ’m");
 
                 isSearch = false;
-                isRaycast = false;
+                //isRaycast = false;
             }
             else
             {

--- a/work/CaseStudy/Assets/2D/Script/Enemy/SEnemyMove.cs
+++ b/work/CaseStudy/Assets/2D/Script/Enemy/SEnemyMove.cs
@@ -182,55 +182,55 @@ public class SEnemyMove : MonoBehaviour
         // 今フレームの接地判定を取得
         isGroundNow = sc_GroundCheck.GroundCheck();
 
-        //坂道計算
-        //傾きを計算するためのポジションを取得
-        slopeOrigin1 = transform.position;
-        slopeOrigin1.x += slopeGup1.x;
-        slopeOrigin1.y += slopeGup1.y;
-        slopeOrigin2 = transform.position;
-        slopeOrigin2.x += slopeGup2.x;
-        slopeOrigin2.y += slopeGup2.y;
+        ////坂道計算
+        ////傾きを計算するためのポジションを取得
+        //slopeOrigin1 = transform.position;
+        //slopeOrigin1.x += slopeGup1.x;
+        //slopeOrigin1.y += slopeGup1.y;
+        //slopeOrigin2 = transform.position;
+        //slopeOrigin2.x += slopeGup2.x;
+        //slopeOrigin2.y += slopeGup2.y;
 
-        RaycastHit2D hitSlope1 = Physics2D.Raycast(slopeOrigin1, Vector2.down, 2.0f);
-        RaycastHit2D hitSlope2 = Physics2D.Raycast(slopeOrigin2, Vector2.down, 2.0f);
-        if (hitSlope1.collider != null && hitSlope2.collider != null &&
-            hitSlope1.collider.CompareTag("TileMap") && hitSlope2.collider.CompareTag("TileMap"))
-        {
-            //2点間の傾きを計算
-            Vector2 point1 = hitSlope1.point;
-            Vector2 point2 = hitSlope2.point;
-            float slopeAngle = Mathf.Atan2(point2.y - point1.y, point2.x - point1.x) * Mathf.Rad2Deg;
-            int isRight = IsReflectionX ? -1 : 1;
+        //RaycastHit2D hitSlope1 = Physics2D.Raycast(slopeOrigin1, Vector2.down, 2.0f);
+        //RaycastHit2D hitSlope2 = Physics2D.Raycast(slopeOrigin2, Vector2.down, 2.0f);
+        //if (hitSlope1.collider != null && hitSlope2.collider != null &&
+        //    hitSlope1.collider.CompareTag("TileMap") && hitSlope2.collider.CompareTag("TileMap"))
+        //{
+        //    //2点間の傾きを計算
+        //    Vector2 point1 = hitSlope1.point;
+        //    Vector2 point2 = hitSlope2.point;
+        //    float slopeAngle = Mathf.Atan2(point2.y - point1.y, point2.x - point1.x) * Mathf.Rad2Deg;
+        //    int isRight = IsReflectionX ? -1 : 1;
 
-            if (slopeAngle < 170 && slopeAngle > 10)
-            {
-                Vector2 vel = rb.velocity;
-                vel.x = fLimitSpeed * isRight;
-                rb.velocity = vel;
-                isSlope = true;
-            }
-            else
-            {
-                rb.drag = 1;
-                isSlope = false;
-            }
-            //傾斜の角度が一定以上なら傾いていると判断
+        //    if (slopeAngle < 170 && slopeAngle > 10)
+        //    {
+        //        Vector2 vel = rb.velocity;
+        //        vel.x = fLimitSpeed * isRight;
+        //        rb.velocity = vel;
+        //        isSlope = true;
+        //    }
+        //    else
+        //    {
+        //        rb.drag = 1;
+        //        isSlope = false;
+        //    }
+        //    //傾斜の角度が一定以上なら傾いていると判断
 
-            //傾きに対する抵抗力を計算
-            //傾斜に対する水平方向の抗力を計算
-            float horizontalResistance = rb.mass * Mathf.Abs(rb.gravityScale) * frictionCoefficient * Mathf.Sin(slopeAngle * Mathf.Deg2Rad);
-            Vector2 vecAngle = new Vector2(Mathf.Cos(slopeAngle * Mathf.Deg2Rad), Mathf.Sin(slopeAngle * Mathf.Deg2Rad));
+        //    //傾きに対する抵抗力を計算
+        //    //傾斜に対する水平方向の抗力を計算
+        //    float horizontalResistance = rb.mass * Mathf.Abs(rb.gravityScale) * frictionCoefficient * Mathf.Sin(slopeAngle * Mathf.Deg2Rad);
+        //    Vector2 vecAngle = new Vector2(Mathf.Cos(slopeAngle * Mathf.Deg2Rad), Mathf.Sin(slopeAngle * Mathf.Deg2Rad));
 
-            Vector2 resistanceForce = vecAngle * horizontalResistance;
-            if (IsReflectionX)
-            {
-                rb.AddForce(resistanceForce * Power * 20, ForceMode2D.Force);
-            }
-            else
-            {
-                rb.AddForce(resistanceForce * (Power / 2), ForceMode2D.Force);
-            }
-        }
+        //    Vector2 resistanceForce = vecAngle * horizontalResistance;
+        //    if (IsReflectionX)
+        //    {
+        //        rb.AddForce(resistanceForce * Power * 20, ForceMode2D.Force);
+        //    }
+        //    else
+        //    {
+        //        rb.AddForce(resistanceForce * (Power / 2), ForceMode2D.Force);
+        //    }
+        //}
 
 
         //この辺コードくっそ汚いので気が向いたら直しておきます


### PR DESCRIPTION
敵の索敵とプレイヤーの風用のレイを一度きりのチェックから、何度もチェックするように修正した。
敵の視野範囲より風の範囲の方が広いので正面から押せてしまうので要調整。