### PR TITLE
プレイヤーのホログラムエラーでてたので修正

### DIFF
--- a/work/CaseStudy/Assets/2D/Object/Player/saisin/Player.prefab
+++ b/work/CaseStudy/Assets/2D/Object/Player/saisin/Player.prefab
@@ -384,7 +384,7 @@ MonoBehaviour:
   acRespawn: {fileID: 8300000, guid: 3c57f0472cee5cc44a8ab08032b4d8d2, type: 3}
   acHit: {fileID: 8300000, guid: afeae751edb938a408622e7144cee9bd, type: 3}
   acCheckPoint: {fileID: 8300000, guid: 3c57f0472cee5cc44a8ab08032b4d8d2, type: 3}
-  RespwanTime: 3
+  RespwanTime: 3.5
   SmokePrefab: {fileID: 7367885248579283801, guid: 0ee9ef57aada90a46848a92f5e86d45d, type: 3}
   SmokeOffset: {x: 0, y: 0}
   acSmokeScreen: {fileID: 8300000, guid: 4f5008068b5b96d4a9928bbce96a3e11, type: 3}

--- a/work/CaseStudy/Assets/2D/Scenes/N_TestScene/NTestScene_3.unity
+++ b/work/CaseStudy/Assets/2D/Scenes/N_TestScene/NTestScene_3.unity
@@ -1953,7 +1953,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6372921232022759936, guid: c793d23110b397448b2ff7991f372973, type: 3}
       propertyPath: isProjection
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6372921232022759936, guid: c793d23110b397448b2ff7991f372973, type: 3}
       propertyPath: AwayDistance.y
@@ -2214,11 +2214,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6372921232022759936, guid: c793d23110b397448b2ff7991f372973, type: 3}
       propertyPath: isProjection
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6372921232022759936, guid: c793d23110b397448b2ff7991f372973, type: 3}
       propertyPath: AwayDistance.y
-      value: 0
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6372921232022759937, guid: c793d23110b397448b2ff7991f372973, type: 3}
       propertyPath: m_RootOrder

--- a/work/CaseStudy/Assets/2D/Script/Camera/N_PostProcess.cs
+++ b/work/CaseStudy/Assets/2D/Script/Camera/N_PostProcess.cs
@@ -27,6 +27,16 @@ public class N_PostProcess : MonoBehaviour
 
     private bool isInit = false;
 
+    public int GetSearchNum()
+    {
+        return SearchManagerNum;
+    }
+
+    public void SetSearchNum(int _num)
+    {
+        SearchManagerNum = _num;
+    }
+
     private void Initialize()
     {
         postVolume = GetComponent<Volume>();

--- a/work/CaseStudy/Assets/2D/Script/Enemy/N_EnemyManager.cs
+++ b/work/CaseStudy/Assets/2D/Script/Enemy/N_EnemyManager.cs
@@ -565,6 +565,7 @@ public class N_EnemyManager : MonoBehaviour
 
     private void ChaseInit()
     {
+        Debug.Log("Add");
         postProcess.AddSerachNum();
 
         managerState = ManagerState.CHASE;
@@ -640,6 +641,7 @@ public class N_EnemyManager : MonoBehaviour
             Target = null;
             managerState = ManagerState.PATOROL;
             ElapsedLostSightTime = 0.0f;
+            Debug.Log("Sub");
 
             postProcess.SubSerachNum();
 
@@ -676,6 +678,10 @@ public class N_EnemyManager : MonoBehaviour
     {
         if (Target == null || Target != _obj)
         {
+            if(postProcess.GetSearchNum() > 0)
+            {
+                postProcess.SetSearchNum(0);
+            }
             Target = _obj;
             TargetTrans = Target.GetComponent<Transform>();
             managerState = ManagerState.FOUND;

--- a/work/CaseStudy/Assets/2D/Script/Enemy/N_PlayerSearch.cs
+++ b/work/CaseStudy/Assets/2D/Script/Enemy/N_PlayerSearch.cs
@@ -89,6 +89,15 @@ public class N_PlayerSearch : MonoBehaviour
                     isRaycast = false;
                     elapsedTime = 0.0f;
                 }
+
+                if(Target.GetComponent<BoxCollider2D>().enabled == false)
+                {
+                    isSearch = false;
+                    isRaycast = false;
+                    elapsedTime = 0.0f;
+                    isCheck = false;
+
+                }
             }
         }
     }

--- a/work/CaseStudy/Assets/2D/Script/Object/N_HoloPlayerDestroy.cs
+++ b/work/CaseStudy/Assets/2D/Script/Object/N_HoloPlayerDestroy.cs
@@ -15,6 +15,10 @@ public class N_HoloPlayerDestroy : MonoBehaviour
 
     private bool init = false;
 
+    private bool onAlpha = false;
+
+    private BoxCollider2D boxCol;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -28,8 +32,14 @@ public class N_HoloPlayerDestroy : MonoBehaviour
         {
             spriteRenderer = transform.GetChild(3).GetComponent<SpriteRenderer>();
             projectHologram = gameObject.transform.parent.GetComponent<N_ProjectHologram>();
+            boxCol = gameObject.GetComponent<BoxCollider2D>();
 
             init = true;
+        }
+
+        if (onAlpha)
+        {
+            OnAlpha();
         }
 
         if (AlphaDown)
@@ -44,6 +54,8 @@ public class N_HoloPlayerDestroy : MonoBehaviour
                 if(color.a < 0.0f)
                 {
                     color.a = 0.0f;
+
+                    boxCol.enabled = false;
 
                     AlphaDown = false;
                     projectHologram.SetOnOff(false);
@@ -64,10 +76,20 @@ public class N_HoloPlayerDestroy : MonoBehaviour
 
     public void OnAlpha()
     {
-        Color color = spriteRenderer.color;
+        if (spriteRenderer != null)
+        {
+            boxCol.enabled = true;
+            Color color = spriteRenderer.color;
 
-        color = new Color(color.a, color.g, color.b, 1.0f);
+            color = new Color(color.a, color.g, color.b, 1.0f);
 
-        spriteRenderer.color = color;
+            spriteRenderer.color = color;
+
+            onAlpha = false;
+        }
+        else
+        {
+            onAlpha = true;
+        }
     }
 }

--- a/work/CaseStudy/Assets/2D/Script/Object/N_ProjectHologram.cs
+++ b/work/CaseStudy/Assets/2D/Script/Object/N_ProjectHologram.cs
@@ -178,7 +178,7 @@ public class N_ProjectHologram : MonoBehaviour
                         obj.transform.position = InitHoloPos;
 
                         // è¡Ç¶ÇΩÉzÉçÉOÉâÉÄÇå©Ç¶ÇÈÇÊÇ§Ç…Ç∑ÇÈ
-                        obj.GetComponent<N_HoloPlayerDestroy>().OnAlpha();
+                        //obj.GetComponent<N_HoloPlayerDestroy>().OnAlpha();
                     }
                 }
                 isActive = true;


### PR DESCRIPTION
プレイヤーのホログラムが死んだ後も判定残ってたんでけした。
画面遷移エフェクトのプレハブの値が違ってたので修正。画面全体が暗くなってから遷移するようになったはず。