### PR TITLE
1-6右のホログラムが敵を押せないバグ修正

### DIFF
--- a/work/CaseStudy/Assets/2D/Scenes/N_TestScene/NTestScene_3.unity
+++ b/work/CaseStudy/Assets/2D/Scenes/N_TestScene/NTestScene_3.unity
@@ -37239,7 +37239,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1606556052}
   m_Layer: 0
-  m_Name: EnemyKari
+  m_Name: Enemy
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/work/CaseStudy/Assets/2D/Script/Player/M_PlayerPush.cs
+++ b/work/CaseStudy/Assets/2D/Script/Player/M_PlayerPush.cs
@@ -85,7 +85,7 @@ public class M_PlayerPush : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        PlayerObj = GameObject.Find("Player");
+        PlayerObj = gameObject.transform.parent.gameObject;
 
         PlayerMove = PlayerObj.GetComponent<M_PlayerMove>();
 


### PR DESCRIPTION
レイの開始位置がホログラムじゃなく、プレイヤーになっていたから押せなくなっていた。