### PR TITLE
敵落下後の挙動バグ

### DIFF
--- a/work/CaseStudy/Assets/2D/Script/Enemy/N_EnemyManager.cs
+++ b/work/CaseStudy/Assets/2D/Script/Enemy/N_EnemyManager.cs
@@ -98,7 +98,7 @@ public class N_EnemyManager : MonoBehaviour
     private ManagerState managerState = ManagerState.PATOROL;
 
     // 追跡対象の座標
-    private GameObject Target;
+    public GameObject Target;
     private Transform TargetTrans;
 
     private N_PostProcess postProcess;
@@ -469,6 +469,7 @@ public class N_EnemyManager : MonoBehaviour
                 obj.GetComponent<K_EnemyReaction>().AllSetFalse();
                 obj.transform.GetChild(2).GetComponent<Animator>().SetBool("dash", true);
             }
+            Target = null;
         }
 
         float dir = 1.0f;

--- a/work/CaseStudy/Assets/2D/Script/Enemy/N_PlayerSearch.cs
+++ b/work/CaseStudy/Assets/2D/Script/Enemy/N_PlayerSearch.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class N_PlayerSearch : MonoBehaviour
 {
-    private N_EnemyManager enemyManager;
+    public N_EnemyManager enemyManager;
     private SEnemyMove enemyMove;
     private S_EnemyBall enemyBall;
 
@@ -87,6 +87,7 @@ public class N_PlayerSearch : MonoBehaviour
                     isSearch = false;
                     isRaycast = false;
                     elapsedTime = 0.0f;
+                    Debug.Log("gomi");
                 }
 
                 if(Target.GetComponent<BoxCollider2D>().enabled == false)
@@ -95,6 +96,7 @@ public class N_PlayerSearch : MonoBehaviour
                     isRaycast = false;
                     elapsedTime = 0.0f;
                     isCheck = false;
+                    Debug.Log("kuso");
 
                 }
             }
@@ -178,13 +180,13 @@ public class N_PlayerSearch : MonoBehaviour
         // ï«Ç…ìñÇΩÇ¡ÇΩÇÁÇ»Ç…Ç‡Ç»Çµ
         if (hit.collider != null)
         {
-            //Debug.Log("ÉqÉbÉgÇµÇΩ");
+            Debug.Log("ÉqÉbÉgÇµÇΩ");
             elapsedTime = 0.0f;
             isCheck = true;
 
             if (hit.collider.gameObject.CompareTag("Player") || hit.collider.gameObject.CompareTag("Decoy"))
             {
-                //Debug.Log("ê⁄ìG");
+                Debug.Log("ê⁄ìG");
                 isSearch = true;
                 enemyManager.SetTarget(Target);
                 //isRaycast = false;
@@ -201,7 +203,7 @@ public class N_PlayerSearch : MonoBehaviour
             }
             else if(hit.collider.gameObject.CompareTag("Ground"))
             {
-                //Debug.Log("ï«åüím");
+                Debug.Log("ï«åüím");
 
                 isSearch = false;
                 //isRaycast = false;
@@ -210,12 +212,12 @@ public class N_PlayerSearch : MonoBehaviour
             }
             else
             {
-                //Debug.Log("Ç»ÇÒÇ©à·Ç§Ç‡ÇÃ");
+                Debug.Log("Ç»ÇÒÇ©à·Ç§Ç‡ÇÃ");
             }
         }
         else
         {
-            //Debug.Log("ÉqÉbÉgÇ»Çµ");
+            Debug.Log("ÉqÉbÉgÇ»Çµ");
         }
     }
 

--- a/work/CaseStudy/Assets/2D/Script/Enemy/SEnemyMove.cs
+++ b/work/CaseStudy/Assets/2D/Script/Enemy/SEnemyMove.cs
@@ -79,7 +79,7 @@ public class SEnemyMove : MonoBehaviour
     // 隊列内での番号
     public int TeamNumber = 0;
 
-    private N_EnemyManager enemyManager;
+    public N_EnemyManager enemyManager;
 
     private Transform thisTrans;
 


### PR DESCRIPTION
敵に見つかった状態で落下するとバグる問題修正。
敵がプレイヤーを見つけて見失ってを繰り返す場合は所属するマネージャーに登録する順番が間違っている可能性が高いです。マネージャーに所属する中でx座標が小さいものから順にインスペクターのリストに登録してください